### PR TITLE
Native text context menu parity

### DIFF
--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -4,6 +4,30 @@ require('./rt/electron-rt');
 console.log('User Preload!');
 import { contextBridge, shell, ipcRenderer } from 'electron';
 
+type NativeContextMenuAction = {
+  id: string;
+  label: string;
+  enabled?: boolean;
+};
+
+type NativeContextMenuContext = {
+  hasSelection?: boolean;
+  selectionText?: string;
+  isEditable?: boolean;
+  linkURL?: string;
+};
+
+type NativeContextMenuRequest = {
+  requestId: string;
+  actions?: NativeContextMenuAction[];
+  context?: NativeContextMenuContext;
+};
+
+type NativeContextMenuActionEvent = {
+  requestId: string;
+  actionId: string;
+};
+
 try {
   // Expose Electron API
   contextBridge.exposeInMainWorld('electronAPI', {
@@ -139,6 +163,25 @@ try {
   });
 
   ipcRenderer.send('test-ipc');
+
+  contextBridge.exposeInMainWorld('nativeContextMenu', {
+    showMenu: (payload: NativeContextMenuRequest) => {
+      if (!payload || typeof payload !== 'object') {
+        return;
+      }
+      ipcRenderer.invoke('native-context-menu:show', payload);
+    },
+    onAction: (callback: (data: NativeContextMenuActionEvent) => void) => {
+      const channel = 'native-context-menu:action';
+      const handler = (_event: unknown, data: NativeContextMenuActionEvent) => {
+        callback?.(data);
+      };
+      ipcRenderer.on(channel, handler);
+      return () => {
+        ipcRenderer.removeListener(channel, handler);
+      };
+    },
+  });
 } catch (error) {
   console.log('error', error);
 }

--- a/electron/src/setup.ts
+++ b/electron/src/setup.ts
@@ -5,7 +5,7 @@ import {
   setupCapacitorElectronPlugins,
 } from '@capacitor-community/electron';
 import chokidar from 'chokidar';
-import type { MenuItemConstructorOptions } from 'electron';
+import type { MenuItemConstructorOptions, WebContents } from 'electron';
 import {
   app,
   BrowserWindow,
@@ -16,6 +16,8 @@ import {
   session,
   ipcMain,
   dialog,
+  clipboard,
+  shell,
 } from 'electron';
 import electronIsDev from 'electron-is-dev';
 import electronServe from 'electron-serve';
@@ -64,6 +66,25 @@ const defaultDomains = [
 // let allowedDomains: string[] = [...defaultDomains]
 const domainHolder = {
   allowedDomains: [...defaultDomains],
+};
+
+type NativeContextMenuAction = {
+  id: string;
+  label: string;
+  enabled?: boolean;
+};
+
+type NativeContextMenuContext = {
+  hasSelection?: boolean;
+  selectionText?: string;
+  isEditable?: boolean;
+  linkURL?: string;
+};
+
+type NativeContextMenuRequest = {
+  requestId: string;
+  actions?: NativeContextMenuAction[];
+  context?: NativeContextMenuContext;
 };
 // Define components for a watcher to detect when the webapp is changed so we can reload in Dev mode.
 const reloadWatcher = {
@@ -477,6 +498,34 @@ ipcMain.handle('fs:selectAndZip', async (_, path) => {
   }
 });
 
+ipcMain.handle(
+  'native-context-menu:show',
+  (event, payload: NativeContextMenuRequest) => {
+    try {
+      if (!payload || typeof payload !== 'object') return;
+      if (typeof payload.requestId !== 'string' || !payload.requestId) return;
+      if (!shouldShowMenu(payload)) return;
+
+      const browserWindow = BrowserWindow.fromWebContents(event.sender);
+      if (!browserWindow || browserWindow.isDestroyed()) return;
+
+      const template = buildNativeMenuTemplate(
+        {
+          requestId: payload.requestId,
+          context: sanitizeContextDetails(payload.context),
+          actions: payload.actions,
+        },
+        event.sender
+      );
+
+      if (!template.length) return;
+      Menu.buildFromTemplate(template).popup({ window: browserWindow });
+    } catch (error) {
+      console.error('Failed to show native context menu', error);
+    }
+  }
+);
+
 // Helper to get or create the shared settings directory
 export async function getSharedSettingsFilePath(
   fileName: string
@@ -832,3 +881,140 @@ ipcMain.handle('coreSetup:pickQortalDirectory', async () => {
     return false;
   }
 });
+const sanitizeContextDetails = (
+  context?: NativeContextMenuContext
+): NativeContextMenuContext => {
+  if (!context || typeof context !== 'object') {
+    return {};
+  }
+
+  const sanitized: NativeContextMenuContext = {};
+
+  if (context.hasSelection) {
+    sanitized.hasSelection = true;
+  }
+  if (typeof context.selectionText === 'string') {
+    sanitized.selectionText = context.selectionText;
+  }
+  if (context.isEditable) {
+    sanitized.isEditable = true;
+  }
+  if (typeof context.linkURL === 'string' && context.linkURL.length > 0) {
+    sanitized.linkURL = context.linkURL;
+  }
+
+  return sanitized;
+};
+
+const getContextMenuDefaults = (
+  context?: NativeContextMenuContext
+): MenuItemConstructorOptions[] => {
+  if (!context) return [];
+
+  const template: MenuItemConstructorOptions[] = [];
+  const hasSelection =
+    typeof context.selectionText === 'string' &&
+    context.selectionText.trim().length > 0;
+
+  if (context.isEditable) {
+    template.push(
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { type: 'separator' },
+      { role: 'selectAll' }
+    );
+  } else if (hasSelection || context.hasSelection) {
+    template.push(
+      { role: 'copy' },
+      { type: 'separator' },
+      { role: 'selectAll' }
+    );
+  }
+
+  if (context.linkURL) {
+    if (template.length) {
+      template.push({ type: 'separator' });
+    }
+    template.push(
+      {
+        label: 'Open Link in Browser',
+        click: () => {
+          try {
+            shell.openExternal(context.linkURL!);
+          } catch (error) {
+            console.error('Failed to open link', error);
+          }
+        },
+      },
+      {
+        label: 'Copy Link Address',
+        click: () => {
+          try {
+            clipboard.writeText(context.linkURL!);
+          } catch (error) {
+            console.error('Failed to copy link', error);
+          }
+        },
+      }
+    );
+  }
+
+  return template;
+};
+
+const buildNativeMenuTemplate = (
+  request: NativeContextMenuRequest,
+  sender: WebContents
+): MenuItemConstructorOptions[] => {
+  const template = getContextMenuDefaults(request.context);
+  const actions = Array.isArray(request.actions)
+    ? request.actions.filter(
+        (item): item is NativeContextMenuAction =>
+          !!item &&
+          typeof item.id === 'string' &&
+          item.id.length > 0 &&
+          typeof item.label === 'string' &&
+          item.label.length > 0
+      )
+    : [];
+
+  if (template.length && actions.length) {
+    template.push({ type: 'separator' });
+  }
+
+  actions.forEach((action) => {
+    template.push({
+      label: action.label,
+      enabled: action.enabled !== false,
+      click: () => {
+        sender.send('native-context-menu:action', {
+          requestId: request.requestId,
+          actionId: action.id,
+        });
+      },
+    });
+  });
+
+  return template;
+};
+
+const shouldShowMenu = (request?: NativeContextMenuRequest) => {
+  if (!request) return false;
+  const hasCustomActions = Array.isArray(request.actions)
+    ? request.actions.some(
+        (action) =>
+          action &&
+          typeof action.id === 'string' &&
+          action.id.length > 0 &&
+          typeof action.label === 'string' &&
+          action.label.length > 0
+      )
+    : false;
+
+  const hasDefaults = getContextMenuDefaults(request.context).length > 0;
+  return hasCustomActions || hasDefaults;
+};

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -12,6 +12,7 @@ import NotificationsOffIcon from '@mui/icons-material/NotificationsOff';
 import { executeEvent } from '../utils/events';
 import { mutedGroupsAtom } from '../atoms/global';
 import { useAtom } from 'jotai';
+import { shouldAllowNativeContextMenu } from '../utils/nativeContextMenu';
 
 const CustomStyledMenu = styled(Menu)(({ theme }) => ({
   '& .MuiPaper-root': {
@@ -43,6 +44,9 @@ export const ContextMenu = ({ children, groupId, getUserSettings }) => {
 
   // Handle right-click (context menu) for desktop
   const handleContextMenu = (event) => {
+    if (shouldAllowNativeContextMenu(event)) {
+      return;
+    }
     event.preventDefault();
     event.stopPropagation(); // Prevent parent click
 

--- a/src/components/ContextMenuMentions.tsx
+++ b/src/components/ContextMenuMentions.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react';
 import { Menu, MenuItem, Typography, styled } from '@mui/material';
+import { shouldAllowNativeContextMenu } from '../utils/nativeContextMenu';
 
 const CustomStyledMenu = styled(Menu)(({ theme }) => ({
   '& .MuiPaper-root': {
@@ -29,6 +30,9 @@ export const ContextMenuMentions = ({
 
   // Handle right-click (context menu) for desktop
   const handleContextMenu = (event) => {
+    if (shouldAllowNativeContextMenu(event)) {
+      return;
+    }
     event.preventDefault();
     event.stopPropagation(); // Prevent parent click
 

--- a/src/components/ContextMenuPinnedApps.tsx
+++ b/src/components/ContextMenuPinnedApps.tsx
@@ -11,6 +11,7 @@ import PushPinIcon from '@mui/icons-material/PushPin';
 import { saveToLocalStorage } from './Apps/AppsNavBarDesktop';
 import { sortablePinnedAppsAtom } from '../atoms/global';
 import { useSetAtom } from 'jotai';
+import { shouldAllowNativeContextMenu } from '../utils/nativeContextMenu';
 
 const CustomStyledMenu = styled(Menu)(({ theme }) => ({
   '& .MuiPaper-root': {
@@ -41,6 +42,9 @@ export const ContextMenuPinnedApps = ({ children, app, isMine }) => {
 
   const handleContextMenu = (event) => {
     if (isMine) return;
+    if (shouldAllowNativeContextMenu(event)) {
+      return;
+    }
     event.preventDefault();
     event.stopPropagation();
     preventClick.current = true;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,9 @@ import { ThemeProvider } from './components/Theme/ThemeContext.tsx';
 import { CssBaseline } from '@mui/material';
 import './i18n/i18n.js';
 import { OnLaunchWrapper } from './OnLaunchWrapper.tsx';
+import { initializeNativeContextMenu } from './utils/nativeContextMenu.ts';
+
+initializeNativeContextMenu();
 
 createRoot(document.getElementById('root')!).render(
   <>

--- a/src/types/native-context-menu.d.ts
+++ b/src/types/native-context-menu.d.ts
@@ -1,0 +1,38 @@
+export {};
+
+declare global {
+  interface NativeContextMenuActionPayload {
+    id: string;
+    label: string;
+    enabled?: boolean;
+  }
+
+  interface NativeContextMenuContextPayload {
+    hasSelection?: boolean;
+    selectionText?: string;
+    isEditable?: boolean;
+    linkURL?: string;
+  }
+
+  interface NativeContextMenuRequestPayload {
+    requestId: string;
+    actions?: NativeContextMenuActionPayload[];
+    context?: NativeContextMenuContextPayload;
+  }
+
+  interface NativeContextMenuActionEvent {
+    requestId: string;
+    actionId: string;
+  }
+
+  interface NativeContextMenuAPI {
+    showMenu: (payload: NativeContextMenuRequestPayload) => void;
+    onAction: (
+      callback: (event: NativeContextMenuActionEvent) => void
+    ) => () => void;
+  }
+
+  interface Window {
+    nativeContextMenu?: NativeContextMenuAPI;
+  }
+}

--- a/src/utils/nativeContextMenu.ts
+++ b/src/utils/nativeContextMenu.ts
@@ -1,0 +1,216 @@
+import type { MouseEvent as ReactMouseEvent } from 'react';
+
+type SupportedEvent = ReactMouseEvent<HTMLElement> | MouseEvent;
+
+type CustomAction = {
+  id: string;
+  label: string;
+  onSelect: () => void;
+  enabled?: boolean;
+};
+
+type PendingMenu = {
+  actions: Record<string, () => void>;
+  cleanupTimeout?: number;
+};
+
+type NativeContextMenuEvent = {
+  requestId: string;
+  actionId: string;
+};
+
+type NativeContextDetails = {
+  hasSelection?: boolean;
+  selectionText?: string;
+  isEditable?: boolean;
+  linkURL?: string;
+};
+
+const EDITABLE_SELECTOR =
+  'input, textarea, [contenteditable="true"], [contenteditable=""]';
+export const NATIVE_CONTEXT_MENU_ATTR = 'data-no-electron-context-menu';
+
+const pendingMenus = new Map<string, PendingMenu>();
+let actionListenerCleanup: (() => void) | null = null;
+let defaultListenerRegistered = false;
+
+const canUseNativeMenu = () =>
+  typeof window !== 'undefined' && !!window.nativeContextMenu?.showMenu;
+
+const isEditableElement = (element?: HTMLElement | null) => {
+  if (!element) return false;
+  if (element.isContentEditable) return true;
+  return element.matches?.(EDITABLE_SELECTOR) ?? false;
+};
+
+const findLinkTarget = (element?: HTMLElement | null) => {
+  if (!element?.closest) return undefined;
+  const anchor = element.closest('a[href]') as HTMLAnchorElement | null;
+  if (anchor?.href) {
+    return anchor.href;
+  }
+  const qortalNode = element.closest('[data-url]') as HTMLElement | null;
+  if (!qortalNode) return undefined;
+  const raw = qortalNode.getAttribute('data-url') || '';
+  const lower = raw.trim().toLowerCase();
+  if (lower.startsWith('qortal://') || lower.startsWith('qortal:')) {
+    return raw;
+  }
+  return undefined;
+};
+
+const hasSelectedText = (target?: HTMLElement | null) => {
+  if (typeof window === 'undefined') return false;
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed) return false;
+  const text = selection.toString();
+  if (!text || !text.trim().length) return false;
+  if (!target) return true;
+  try {
+    return selection.containsNode(target, true);
+  } catch {
+    return false;
+  }
+};
+
+const hasNativeOptOut = (element?: HTMLElement | null) =>
+  !!element?.closest?.(`[${NATIVE_CONTEXT_MENU_ATTR}]`);
+
+const buildContextDetails = (event: SupportedEvent): NativeContextDetails => {
+  if (typeof window === 'undefined') return {};
+  const target = (event.target ||
+    (event as any).srcElement) as HTMLElement | null;
+  const selection = window.getSelection();
+  const selectionText = selection?.toString() ?? '';
+  const selectionIncludesTarget = hasSelectedText(target);
+  return {
+    hasSelection: selectionIncludesTarget,
+    selectionText: selectionIncludesTarget ? selectionText : undefined,
+    isEditable: isEditableElement(target),
+    linkURL: findLinkTarget(target),
+  };
+};
+
+const registerActionListener = () => {
+  if (actionListenerCleanup || !canUseNativeMenu()) return;
+  const api = window.nativeContextMenu;
+  if (!api?.onAction) return;
+  actionListenerCleanup = api.onAction((event: NativeContextMenuEvent) => {
+    if (!event) return;
+    const pending = pendingMenus.get(event.requestId);
+    if (!pending) return;
+    if (pending.cleanupTimeout) {
+      window.clearTimeout(pending.cleanupTimeout);
+    }
+    pendingMenus.delete(event.requestId);
+    pending.actions[event.actionId]?.();
+  });
+};
+
+const shouldShowMenu = (
+  context: NativeContextDetails,
+  actions: CustomAction[]
+) => {
+  const hasDefaults =
+    context.isEditable ||
+    !!context.linkURL ||
+    !!(context.selectionText && context.selectionText.trim().length > 0) ||
+    context.hasSelection;
+  const hasCustom = actions.length > 0;
+  return hasDefaults || hasCustom;
+};
+
+const normalizeActions = (actions?: CustomAction[]) =>
+  Array.isArray(actions)
+    ? actions.filter(
+        (action): action is CustomAction =>
+          !!action &&
+          typeof action.id === 'string' &&
+          action.id.length > 0 &&
+          typeof action.label === 'string' &&
+          action.label.length > 0 &&
+          typeof action.onSelect === 'function'
+      )
+    : [];
+
+const generateRequestId = () =>
+  `native-menu-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+export const openNativeContextMenu = (
+  event: SupportedEvent,
+  options?: { actions?: CustomAction[] }
+) => {
+  if (!canUseNativeMenu()) return false;
+
+  const context = buildContextDetails(event);
+  const customActions = normalizeActions(options?.actions);
+  if (!shouldShowMenu(context, customActions)) {
+    return false;
+  }
+
+  registerActionListener();
+  event.preventDefault?.();
+  event.stopPropagation?.();
+
+  const requestId = generateRequestId();
+  const actionMap: Record<string, () => void> = {};
+  customActions.forEach((action) => {
+    actionMap[action.id] = action.onSelect;
+  });
+
+  const cleanupTimeout =
+    typeof window === 'undefined'
+      ? undefined
+      : window.setTimeout(() => {
+          pendingMenus.delete(requestId);
+        }, 10000);
+
+  pendingMenus.set(requestId, { actions: actionMap, cleanupTimeout });
+
+  window.nativeContextMenu?.showMenu({
+    requestId,
+    context,
+    actions: customActions.map(({ id, label, enabled = true }) => ({
+      id,
+      label,
+      enabled,
+    })),
+  });
+
+  return true;
+};
+
+export const shouldAllowNativeContextMenu = (event: SupportedEvent) => {
+  const target = (event.target ||
+    (event as any).srcElement) as HTMLElement | null;
+  if (!target) return false;
+  if (hasNativeOptOut(target)) return true;
+  if (isEditableElement(target)) return true;
+  return hasSelectedText(target);
+};
+
+export const initializeNativeContextMenu = () => {
+  if (defaultListenerRegistered || !canUseNativeMenu()) {
+    return;
+  }
+  defaultListenerRegistered = true;
+  window.addEventListener(
+    'contextmenu',
+    (event) => {
+      const target = (event.target ||
+        (event as any).srcElement) as HTMLElement | null;
+      if (!target) return;
+      if (hasNativeOptOut(target)) return;
+
+      const editable = isEditableElement(target);
+      const selection = hasSelectedText(target);
+
+      if (!editable && !selection) {
+        return;
+      }
+
+      openNativeContextMenu(event);
+    },
+    true
+  );
+};


### PR DESCRIPTION
Wired a single Electron IPC surface plus renderer helper so editable fields always get OS Cut/Copy/Paste menus while group/pinned/mention context menus skip interception when users right‑click text. New helper also exposes a `data-no-electron-context-menu` opt-out flag for any future components.

**Changes**

- electron/src/preload.ts:5-184 now defines strongly typed `nativeContextMenu` bridge methods so renderer code can trigger/show native menus or subscribe to action callbacks without duplicating IPC plumbing.
- electron/src/setup.ts:71-1020 adds sanitizer/build helpers and the `ipcMain.handle('native-context-menu:show', …)` handler that composes native Undo/Cut/Copy/Paste/Select-All, spell-check selection, and link actions before optionally appending renderer-supplied items; handler validates payloads and no-ops when nothing needs to be shown.
- src/utils/nativeContextMenu.ts:1-216 plus src/types/native-context-menu.d.ts:1-38 introduce the renderer abstraction: it detects editable/selected targets, registers a global capturing listener via initializeNativeContextMenu, exposes `NATIVE_CONTEXT_MENU_ATTR` opt-out support, and offers `shouldAllowNativeContextMenu` helpers so React components can bail out early.
- src/main.tsx:1-24 calls `initializeNativeContextMenu()` before rendering to ensure the global text-field listener is active in every window.
- src/components/ContextMenu.tsx:1-190, ContextMenuPinnedApps.tsx:1-190, and ContextMenuMentions.tsx:1-129 now import `shouldAllowNativeContextMenu` and simply return when a right-click originates from an editable/opted-out descendant, preventing calls to `preventDefault()` that previously blocked OS menus on nested inputs.